### PR TITLE
docs: fix localhost URL in installation instructionsdocs: fix localhost URL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ GEMINI_API_KEY=your_actual_api_key_here
 npm run dev
 ```
 
-5. Open [https://unharmable-threadlike-ruth.ngrok-free.dev:3000](https://unharmable-threadlike-ruth.ngrok-free.dev:3000) in your browser
+5. Open [http://localhost:3000](http://localhost:3000) in your browser
 
 ## Tech Stack
 


### PR DESCRIPTION
Fixed hardcoded ngrok URL to use localhost for local development setup. This ensures new users can follow the installation instructions correctly.